### PR TITLE
Add running script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin/make-make
 examples/*/*.c
 examples/*/*.o
 examples/*/*.s
+examples/*/run
 examples/*/main
 !examples/*/main.c
 examples/*/*.h

--- a/examples/diffusion1/Makefile
+++ b/examples/diffusion1/Makefile
@@ -1,6 +1,5 @@
 CC = mpicc
 CCFLAG = -Wall -std=c99 -lm -O3 -ffast-math -mavx2 -mfma
-N = 1
 .SUFFIXES:
 .PRECIOUS: %.s
 
@@ -18,7 +17,7 @@ main: main.o diffusion1.o
 
 run: main
 	mkdir -p data
-	mpirun -n $(N) ./main
+	./run ./main
 
 clean:
 	rm -rf *.o *.s main

--- a/examples/diffusion2/Makefile
+++ b/examples/diffusion2/Makefile
@@ -1,6 +1,5 @@
 CC = mpicc
 CCFLAG = -Wall -std=c99 -lm -O3 -ffast-math -mavx2 -mfma
-N = 1
 .SUFFIXES:
 .PRECIOUS: %.s
 
@@ -18,7 +17,7 @@ main: main.o diffusion2.o
 
 run: main
 	mkdir -p data
-	mpirun -n $(N) ./main
+	./run ./main
 
 clean:
 	rm -rf *.o *.s main

--- a/examples/diffusion3/Makefile
+++ b/examples/diffusion3/Makefile
@@ -1,6 +1,5 @@
 CC = mpicc
 CCFLAG = -Wall -std=c99 -lm -O3 -ffast-math -mavx2 -mfma
-N = 1
 .SUFFIXES:
 .PRECIOUS: %.s
 
@@ -18,7 +17,7 @@ main: main.o diffusion3.o
 
 run: main
 	mkdir -p data
-	mpirun -n $(N) ./main
+	./run ./main
 
 clean:
 	rm -rf *.o *.s main

--- a/src/Formura/Generator.hs
+++ b/src/Formura/Generator.hs
@@ -168,7 +168,8 @@ genRunningScript :: String -> Int -> IO ()
 genRunningScript fn n = do
   let script = unlines ["#!/bin/bash"
                        ,"prog=${1:?Need an executable file path}"
-                       ,"mpirun -n " ++ show n ++ " ${prog}"
+                       ,"opt=${2}"
+                       ,"mpirun ${opt} -n " ++ show n ++ " ${prog}"
                        ]
   writeFile fn script
   p <- getPermissions fn

--- a/src/Formura/Generator.hs
+++ b/src/Formura/Generator.hs
@@ -12,6 +12,7 @@ import Data.List (isPrefixOf, stripPrefix)
 import qualified Data.Map as M
 import Data.Scientific
 import qualified Data.Text.Lazy.IO as T
+import System.Directory
 import Text.Heterocephalus (compileTextFile)
 import Text.Blaze.Renderer.Text (renderMarkup)
 import Text.Printf
@@ -44,6 +45,8 @@ genCode mm = do
       nqs = zip [0..] $ map fst qs :: [(Int,String)]
       step = mkStep axes $ mm ^. omStepGraph
       with_simd = False
+  let runningScriptPath = "run"
+  genRunningScript runningScriptPath totalMPI
   T.writeFile hxxFilePath $ renderMarkup $(compileTextFile "templates/cpu.h")
   T.writeFile cxxFilePath $ renderMarkup $ case dim of
     1 -> let [a1] = axes in $(compileTextFile "templates/cpu-1d.c")
@@ -53,6 +56,7 @@ genCode mm = do
   putStr . unlines $ [ "Generate:"
                      , "  " ++ cxxFilePath
                      , "  " ++ hxxFilePath
+                     , "  " ++ runningScriptPath
                      ]
 
 mkRanks :: Int -> [String]
@@ -158,3 +162,14 @@ mkStep axes mmg = withTmp $ unlines [ genMMInst omid $ if isVoid omt then mm els
                   -- Naryop op xs -> undefined
                   x -> error $ "Unimplemented for keyword: " ++ show x
       in unwords [lhs, "=", rhs]
+
+
+genRunningScript :: String -> Int -> IO ()
+genRunningScript fn n = do
+  let script = unlines ["#!/bin/bash"
+                       ,"prog=${1:?Need an executable file path}"
+                       ,"mpirun -n " ++ show n ++ " ${prog}"
+                       ]
+  writeFile fn script
+  p <- getPermissions fn
+  setPermissions fn $ p {executable = True}


### PR DESCRIPTION
yaml と一貫したMPIプロセスで実行するための補助スクリプト生成

実行時、`mpirun` に渡すプロセス数は yaml ファイルにあるプロセス数と一貫性がないといけないが、
人間がその整合性を保つのは DRY原則に反する。
そこで、 `run` という補助スクリプトを formura が生成し、ユーザーがそのスクリプトを実行すればMPIプロセス数は勝手に整合するようにした。