### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,25 @@ Note: The originary repo is <https://github.com/nushio3/formura>.
 
 # Quick Start
 
-OS: Ubuntu 18.04
+OS: Ubuntu 18.04, CentOS 7, Mac, WSL
+
+```
+curl -sSfL https://raw.githubusercontent.com/formura/formura/master/install.sh | sh
+```
+
+Add `${HOME}/.formura/bin` to your `PATH` and
+
+```
+formura --version
+```
+
+# Install
+## Download binary (`x86_64`)
+Ubuntu 18.04, CentOS 7, Mac, WSL
+
+```
+curl -sSfL https://raw.githubusercontent.com/formura/formura/master/install.sh | sh
+```
 
 ## Using docker
 ### Pull the image of formura

--- a/README.md
+++ b/README.md
@@ -34,6 +34,27 @@ Ubuntu 18.04, CentOS 7, Mac, WSL
 curl -sSfL https://raw.githubusercontent.com/formura/formura/master/install.sh | sh
 ```
 
+### Upgrade
+
+```
+curl -sSfL https://raw.githubusercontent.com/formura/formura/master/install.sh | sh
+```
+
+### Downgrade
+WSL, Linux:
+
+```
+ln -f -s $HOME/.formura/bin/formura_linux_<version> $HOME/.formura/bin/formura
+```
+
+Mac:
+
+```
+ln -f -s $HOME/.formura/bin/formura_mac_<version> $HOME/.formura/bin/formura
+```
+
+where `<version>` is such like `v2.3.2`.
+
 ## Using docker
 ### Pull the image of formura
 


### PR DESCRIPTION
インストール方法の記述を改善した

バージョンのついたバイナリが保存されるので、バージョンアップした場合も同じスクリプトを実行すればバージョンが上がる。ロールバックしたい場合は手動でシンボリックリンクをはりなおせばよいと考えている。

- WSL (Ubuntu 18.04)
- mac (macOS Sierra version 10.12.6)
- CentOS 7
- Archlinux

では動作確認済。

TODO:

- [x] ダウングレードのやり方を追加
- [x] アップデートのやり方を追加